### PR TITLE
Azure VMSS dies if error is returned

### DIFF
--- a/azure.js
+++ b/azure.js
@@ -45,7 +45,10 @@ module.exports = (args, sendTo) => {
 
   const processVirtualMachineScaleSet = function (client, ips, localIps, vmssName) {
     client.networkInterfaces._listVirtualMachineScaleSetNetworkInterfaces(args.azure, vmssName, function(err, results) {
-      if (err) console.log(err);
+      if (err) {
+        console.log(err);
+        return;
+      }
 
       results.forEach(result => {
         result.ipConfigurations.forEach(ip => {


### PR DESCRIPTION
Solution:  Don't attempt to process the response if it contains an error.